### PR TITLE
stability fix for Matlab's eigh wrapper :balloon:

### DIFF
--- a/sfo.m
+++ b/sfo.m
@@ -1046,7 +1046,9 @@ classdef sfo < handle
             % eigh routine.  (note, eigh further assumes symmetric matrix.  don't
             % think there's an equivalent MATLAB function?)
 
-            [V,U] = eig(A);
+            % Note: this function enforces A to be symmetric
+
+            [V,U] = eig(0.5 * (A + A'));
             U = diag(U);
         end
 


### PR DESCRIPTION
This fixes a bug in the Matlab version of SFO where the `eigh_wrapper` function was returning imaginary values due to a non-symmetric matrix input.

The fix implemented here involves forcing the input to be symmetric by replacing it with it's symmetric counterpart, `(A + A') / 2`.